### PR TITLE
Make MPI, metis/parmetis and PETSc source staging version dependent

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -22,18 +22,20 @@ USER builder
 ENV HOME=/home/builder
 
 # Build and install PFLARE with spack, test it works
-# We build the main branch of PFLARE against three different petsc buids
-# 1) Static libraries
-# 2) Shared libraries
-# 3) Shared libraries + python + kokkos
-# 4) Also build a dummy package pflare-test which depends on pflare to test
+# We build the main branch of PFLARE against four different petsc builds
+# 1) Static libraries, without metis/parmetis
+# 2) Shared libraries + metis/parmetis
+# 3) Shared libraries without MPI (MPIUNI)
+# 4) Shared libraries + python + kokkos
+# 5) Also build a dummy package pflare-test which depends on pflare to test
 #     the linking in spack for dependencies works correctly
 RUN set -e; \
     echo "Cloning branch: ${CHECKOUT_BRANCH}" && \
     git clone --branch ${CHECKOUT_BRANCH} https://github.com/PFLAREProject/PFLARE_spack.git && \
     spack repo add PFLARE_spack && \
-    spack install -v --test=root pflare@main ^petsc~shared && \
-    spack install -v --test=root pflare@main && \
+    spack install -v --test=root pflare@main ^petsc~shared~metis && \
+    spack install -v --test=root pflare@main ^petsc+metis && \
+    spack install -v --test=root pflare@main ^petsc~mpi && \
     spack install -v --test=root pflare@main+python ^petsc+kokkos && \
     spack install -v --test=root pflare-test ^pflare@main
 

--- a/packages/pflare-test/files/Makefile
+++ b/packages/pflare-test/files/Makefile
@@ -2,6 +2,10 @@
 #
 # This follows the PETSc make pattern used in PFLARE tests by including
 # PETSc's conf variables/rules, then prepending pflare libs to LDLIBS.
+#
+# The rules below compile and link in one step rather than going through
+# PETSc's implicit rules, so they have to pass PETSC_{CC,FC}_INCLUDES
+# themselves - nothing else puts PETSc's headers on the include path.
 
 PFLARE_CPPFLAGS ?=
 PFLARE_LDFLAGS  ?=
@@ -26,10 +30,10 @@ LDLIBS := $(PFLARE_LDFLAGS) $(LDLIBS)
 all: pflare_test_c pflare_test_f
 
 pflare_test_c: main.c
-	$(CLINKER) $(CPPFLAGS) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
+	$(CLINKER) $(PETSC_CC_INCLUDES) $(CPPFLAGS) $(CFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
 
 pflare_test_f: main.F90
-	$(FLINKER) $(CPPFLAGS) $(FFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
+	$(FLINKER) $(PETSC_FC_INCLUDES) $(CPPFLAGS) $(FFLAGS) -o $@ $< $(LDFLAGS) $(LDLIBS)
 
 clean::
 	$(RM) -f pflare_test_c pflare_test_f

--- a/packages/pflare/package.py
+++ b/packages/pflare/package.py
@@ -41,18 +41,25 @@ class Pflare(MakefilePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
 
-    depends_on("mpi")
     depends_on("blas")
     depends_on("lapack")
-    depends_on("metis")
-    depends_on("parmetis")
+    depends_on("petsc")
 
-    # Ensure PETSc itself is built with the metis+parmetis support PFLARE
-    # needs at runtime. The depends_on("parmetis") above
-    # alone only guarantees the library is built somewhere in the DAG, not that
-    # PETSc's own configure enabled it (metis/parmetis default to off in the PETSc spack).
-    # +metis variant activates support for both metis and parmetis.
-    depends_on("petsc+metis")
+    # PFLARE 1.26.0 and earlier link MPI, metis and parmetis directly, and require
+    # PETSc itself to have been configured with them. A bare depends_on("parmetis")
+    # only guarantees the library is built somewhere in the DAG, not that PETSc's own
+    # configure enabled it, hence the explicit pin on the PETSc variants (PETSc's
+    # +metis variant activates support for both metis and parmetis).
+    #
+    # Newer versions of PFLARE build against the public PETSc API only. They can compile
+    # against a PETSc configured without MPI (MPIUNI), and fall back to
+    # MATPARTITIONINGAVERAGE when PETSc has no ParMETIS, so all three now follow
+    # whatever PETSc itself pulls in. Build ^petsc+metis for the best parallel
+    # repartitioning performance.
+    depends_on("mpi", when="@:1.26")
+    depends_on("metis", when="@:1.26")
+    depends_on("parmetis", when="@:1.26")
+    depends_on("petsc+mpi+metis", when="@:1.26")
 
     # PETSc version dependencies
     depends_on("petsc@main", when="@main")
@@ -72,10 +79,15 @@ class Pflare(MakefilePackage):
     depends_on("py-petsc4py", when="+python", type=("build", "run"))
 
     # ~~~~~~~~~~~~~~~
-    # The build itself needs private PETSc headers that aren't included in the petsc install
-    # So we tell spack to restage petsc during our build and then we set petsc_src_dir
+    # PFLARE 1.26.0 and earlier build against private PETSc headers that aren't included
+    # in the petsc install, so we tell spack to restage petsc during our build and then
+    # we set petsc_src_dir. Newer versions only use the public PETSc API, so they build
+    # against a plain petsc install (and hence also work with an external petsc).
     # ~~~~~~~~~~~~~~~
     def edit(self, spec, prefix):
+        if not spec.satisfies("@:1.26"):
+            return
+
         # Stage the PETSc source that matches the concretized dependency
         dep_pkg = self.spec["petsc"].package
         dep_pkg.do_stage()  # fetch+expand PETSc sources into its own stage
@@ -98,23 +110,28 @@ class Pflare(MakefilePackage):
             env.set("PYTHONNOUSERSITE", "1")
 
     # ~~~~~~~~~~~~~~~
-    # The build appends the petsc source files into our include flags
+    # For the versions that need it, the build appends the petsc source files into our
+    # include flags
     # ~~~~~~~~~~~~~~~
     def build(self, spec, prefix):
         from spack.util.environment import set_env
         from spack.util.executable import which
 
-        # Use the symlink created in edit()
-        petsc_inc_src = join_path(self.stage.source_path, "petsc_src_dir", "include")
-        if not os.path.isdir(petsc_inc_src):
-            raise InstallError(f"PETSc include directory not found at {petsc_inc_src}")
+        extra_env = {}
+        if spec.satisfies("@:1.26"):
+            # Use the symlink created in edit()
+            petsc_inc_src = join_path(self.stage.source_path, "petsc_src_dir", "include")
+            if not os.path.isdir(petsc_inc_src):
+                raise InstallError(f"PETSc include directory not found at {petsc_inc_src}")
 
-        extra_inc = f"-I{petsc_inc_src}"
-        with set_env(
-            CFLAGS=(f"{os.environ.get('CFLAGS', '')} {extra_inc}").strip(),
-            CXXFLAGS=(f"{os.environ.get('CXXFLAGS', '')} {extra_inc}").strip(),
-            CPPFLAGS=(f"{os.environ.get('CPPFLAGS', '')} {extra_inc}").strip(),
-        ):
+            extra_inc = f"-I{petsc_inc_src}"
+            extra_env = {
+                "CFLAGS": (f"{os.environ.get('CFLAGS', '')} {extra_inc}").strip(),
+                "CXXFLAGS": (f"{os.environ.get('CXXFLAGS', '')} {extra_inc}").strip(),
+                "CPPFLAGS": (f"{os.environ.get('CPPFLAGS', '')} {extra_inc}").strip(),
+            }
+
+        with set_env(**extra_env):
             # The Makefile has a `build_tests_check` target that builds the library and tests
             make("build_tests_check", parallel=True)
             if spec.satisfies("+python"):
@@ -180,6 +197,10 @@ class Pflare(MakefilePackage):
     # ~~~~~~~~~~~~~~~
     @run_after("install")
     def cleanup_petsc_stage(self):
+        # Only 1.26.0 and earlier stage PETSc in edit()
+        if not self.spec.satisfies("@:1.26"):
+            return
+
         # Avoid leaking a staged PETSc tree on disk
         try:
             self.spec["petsc"].package.stage.destroy()


### PR DESCRIPTION
PFLARE `main` no longer requires MPI, metis/parmetis, or a staged copy of the PETSc source, so the recipe should stop forcing all three. Every released version still needs them, so this gates them on `@:1.26` rather than removing them.

## Why

- **PR #245** (`Remove vendoring of the PETSc source`) — PFLARE used to include private PETSc headers (`mpiaij.h`, `aij.h`, `aijkok.hpp`, `veckokkosimpl.hpp`) that are not part of a PETSc install, which is why the recipe restaged the PETSc source and injected `-I<petsc_src>/include`. It now uses only the public PETSc API, so it builds against a plain PETSc install — and therefore also works against an **external** PETSc, which `do_stage()` could never support.
- **PR #243 / #251** — PFLARE builds on a PETSc configured without MPI (MPIUNI), and the only `MatPartitioning` use is guarded by `PETSC_HAVE_PARMETIS` with a `MATPARTITIONINGAVERAGE` fallback. The Makefiles reference no MPI/metis/parmetis symbols at all; everything comes from PETSc's `conf/variables`.

## Changes

`packages/pflare/package.py`

- `mpi`, `metis`, `parmetis` and the PETSc variant pin are now `when="@:1.26"`. Newer versions just `depends_on("petsc")` and follow whatever PETSc itself pulls in.
- The legacy PETSc pin gains `+mpi`. `depends_on("mpi")` only put MPI somewhere in the DAG — it never guaranteed PETSc's own configure enabled it, so `pflare@1.26.0 ^petsc~mpi` used to concretize and then fail to compile. That hole is now closed.
- `edit()`, `build()` and `cleanup_petsc_stage()` skip the PETSc staging, the `-I<petsc_src>/include` injection and the stage teardown for newer versions.

`1.26` is the only version literal introduced, so nothing here refers to an unreleased tag — the next release only needs its `version(...)` line plus whatever PETSc floor it requires.

`dockerfiles/Dockerfile` — now builds `main` against four PETSc configurations instead of three:

| Spec | Covers |
|---|---|
| `^petsc~shared~metis` | static, and no metis/parmetis |
| `^petsc+metis` | metis/parmetis |
| `^petsc~mpi` | MPIUNI |
| `+python ^petsc+kokkos` | unchanged |
| `pflare-test` | downstream linkage |

The no-metis build pins `~metis` explicitly rather than relying on the PETSc variant default, which is **not** stable across Spack versions (`default=False` in current spack-packages, `default=True` in older builtin repos).

## Verification

All run with `spack install --test=root`:

| Build | Result | Evidence |
|---|---|---|
| `pflare@1.24.11` (legacy) | pass, 12m56s | PETSc source restaged and extracted, `-I.../petsc_src_dir/include` present in the C compiles, stage destroyed afterwards, Serial/Serial-F/Parallel checks ran |
| `pflare@main` | pass, 1m57s | zero `petsc_src_dir` references, no PETSc staging at all |
| `pflare@main ^petsc~mpi` | pass, 57s | `Parallel check skipped (PETSc configured without MPI)` |
| `pflare@main ^petsc~shared~metis` | pass, 1m27s | no metis/parmetis `-I`/`-L` flags; Parallel check still ran via the `MATPARTITIONINGAVERAGE` fallback |
| `pflare-test ^pflare@main` | pass, 11s | `pflare_test_c OK`, `pflare_test_f OK` |

The last three were impossible before this change.

Concretization guards behave as intended: `pflare@1.26.0 ^petsc~mpi` and `^petsc~metis` both now correctly refuse to concretize.

`ruff format` and `ruff check` are clean (the only findings are the F403/F405 star-import codes that Spack's own per-file-ignores exempt for package files), and `spack style`'s mypy pass is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)